### PR TITLE
Include current SourceBranch when trigger build

### DIFF
--- a/BuildTasks/triggerbuildtask/triggerbuild.ps1
+++ b/BuildTasks/triggerbuildtask/triggerbuild.ps1
@@ -218,7 +218,7 @@ if ($dependentOnFailedBuildConditionAsBool){
 $buildDefinitionId = Get-BuildDefinition-Id -definition $buildDefinition
 
 $queueBuildUrl = "/build/builds?api-version=2.0"
-$queueBuildBody = "{ definition: { id: $($buildDefinitionId) }}"
+$queueBuildBody = "{ definition: { id: $($buildDefinitionId) }, sourceBranch: $($env:BUILD_SOURCEBRANCH) }"
 
 Write-Output "Queue new Build for definition $($buildDefinition) on $($tfsServer)/_apis/$($queueBuildUrl)"
 


### PR DESCRIPTION
Pass the current SourceBranch to triggered build so we can have builds with the same source from wildcard branches like release/* (gitflow).