### PR TITLE
Add documentation example for passing object template parameter directly

### DIFF
--- a/BuildTasks/overview.md
+++ b/BuildTasks/overview.md
@@ -228,6 +228,22 @@ parameters:
     displayName: Databases
 ```
 
+If you're passing a template parameter directly instead of literal values, you must encode it as a flow-style `[,]` array to avoid parsing errors:
+
+``` yaml
+parameters:
+- name: databases
+  type: object
+  default:
+  - custom
+  - Custom2
+
+# ...
+- task: TriggerBuild@4
+  inputs:
+    templateParameters: 'databases: [${{ join(',', parameters.databases) }}]'
+```
+
 **Note:** This will only work for templateParameters, not for variables.
 
 See [this issue on github](https://github.com/huserben/TfsExtensions/issues/226) for more information.


### PR DESCRIPTION
Add an example for how to pass a template parameter of type `object` to the `templateParameters` input of `TriggerBuild@4`. This requires converting the object input to a flow-style array as parsing errors will be encountered if the parameter value is encoded as a block-style (aka sequence) array. 