### PR TITLE
Fix help markdown url for buildParameters

### DIFF
--- a/BuildTasks/triggerbuildtask/triggerbuildtaskV3/task.json
+++ b/BuildTasks/triggerbuildtask/triggerbuildtaskV3/task.json
@@ -254,7 +254,7 @@
 			"label":  "Define additional parameters for the build, for example build configuration or platform.",
 			"defaultValue":  "",
 			"required":  false,
-			"helpMarkDown":  "Specify the build parameters. If nothing is specified, the default values will be used. See [Build Task description](https://github.com/huserben/TfsExtensions/blob/master/BuildTasks/overview.md#build-parameters) for more info on the format and the usage of variables.",
+			"helpMarkDown":  "Specify the build parameters. If nothing is specified, the default values will be used. See [Build Task description](https://github.com/huserben/TfsExtensions/blob/master/BuildTasks/overview.md#build-and-template-parameters) for more info on the format and the usage of variables.",
 			"groupName":  "advancedConfiguration"
 		},
 		{

--- a/BuildTasks/triggerbuildtask/triggerbuildtaskV4/task.json
+++ b/BuildTasks/triggerbuildtask/triggerbuildtaskV4/task.json
@@ -253,7 +253,7 @@
 			"label": "Define additional parameters for the build, for example build configuration or platform.",
 			"defaultValue": "",
 			"required": false,
-			"helpMarkDown": "Specify the build parameters. If nothing is specified, the default values will be used. See [Build Task description](https://github.com/huserben/TfsExtensions/blob/master/BuildTasks/overview.md#build-parameters) for more info on the format and the usage of variables.",
+			"helpMarkDown": "Specify the build parameters. If nothing is specified, the default values will be used. See [Build Task description](https://github.com/huserben/TfsExtensions/blob/master/BuildTasks/overview.md#build-and-template-parameters) for more info on the format and the usage of variables.",
 			"groupName": "advancedConfiguration"
 		},
 		{


### PR DESCRIPTION
Fix the help url for task input `buildParameters`.